### PR TITLE
remove/update references to deprecated synse-graphql project

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,6 @@ There are a number of components that make up the Synse Ecosystem.
 - [**vapor-ware/synse-cli**][synse-cli]: A CLI that allows you to easily interact with
   Synse Server and Plugins directly from the command line.
 
-- [**vapor-ware/synse-graphql**][synse-graphql]: A GraphQL wrapper around Synse Server's
-  HTTP API that provides a powerful query language enabling simple aggregations and
-  operations over multiple devices. It also provides a [Prometheus][prometheus] exporter
-  for the metrics it gathers.
-
 
 # Synse Plugins
 In addition to the core components listed above, there is a growing collection of plugins
@@ -97,7 +92,6 @@ synse/snmp         	0.1.0        	           	snmp
 [synse-cli]: https://github.com/vapor-ware/synse-cli
 [synse-grpc]: https://github.com/vapor-ware/synse-server-grpc
 [synse-server]: https://github.com/vapor-ware/synse-server
-[synse-graphql]: https://github.com/vapor-ware/synse-graphql
 [synse-cli]: https://github.com/vapor-ware/synse-cli
 [synse-snmp-plugin]: https://github.com/vapor-ware/synse-snmp-plugin
 [synse-emulator-plugin]: https://github.com/vapor-ware/synse-emulator-plugin

--- a/compose/monitoring.yml
+++ b/compose/monitoring.yml
@@ -23,6 +23,9 @@ services:
 
 
   # Synse GraphQL
+  # NOTE: This component is deprecated and will not be supported moving
+  #   forward. This component will be removed when an alternative data
+  #   export method is configured.
   synse-graphql:
     container_name: synse_graphql
     image: vaporio/synse-graphql

--- a/tutorial/monitoring.md
+++ b/tutorial/monitoring.md
@@ -1,5 +1,10 @@
 # Monitoring your physical infrastructure with Synse
 
+> **NOTE:** This tutorial uses the Synse GraphQL project to provide a prometheus
+> exporter for Synse data. The Synse GraphQL project has been deprecated and is
+> no longer supported in any fashion. The references to it are maintained in this
+> tutorial until an alternative workflow for Synse data visualization is configured.
+
 Recent trends in automation are making it faster, easier, and more reliable to
 operate applications and data centers. Containerization and the devops movement
 are all about automating tasks that used to be manual. So far, these have stopped
@@ -7,7 +12,7 @@ at the software layer and treated underlying hardware as if it was homogeneous.
 In the real world, that isn’t the case. Synse provides the missing piece to automate
 your data center from top to bottom.
 
-With Synse, there is now a simple HTTP interface (either JSON or GraphQL) to read
+With Synse, there is now a simple HTTP interface to read
 data from the sensors, devices, and servers in your data center. This can be used
 to integrate with and drive automation systems. When a server gets too warm, the
 workloads on it can be migrated somewhere else without any human intervention.
@@ -124,6 +129,9 @@ more device info, take a look at the [user guide][synse-server-docs] and
 [api docs][synse-server-api-docs].
 
 # Exploring your Infrastructure with GraphQL
+
+> **Note:** Synse GraphQL is deprecated - this section will be replaced once an alternative
+> data export method is configured.
 
 Writing scripts or running lots of CURL commands gets old quickly. GraphQL provides a
 simple interface for querying your infrastructure, exploring what's there and getting


### PR DESCRIPTION
This PR removes Synse GraphQL as a component of the Synse environment. It adds deprecation notes to the monitoring tutorial and compose file. It does not remove Synse GraphQL from the tutorial, as it currently provides the prometheus exporter which is used to visualize the data in the second half of the tutorial.

An alternative method of data export will need to be provided to fully replace Synse GraphQL from this tutorial. It would also require an update to the tutorial video. It may be worthwhile to wait for such a change until Synse v3, as that would require major updates to the tutorial/video anyways.

See also:
- #8 
